### PR TITLE
Handle OUT_DIR being relative to the top directory

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -21,7 +21,7 @@ LOCAL_PACKAGE_NAME := GsfProxy
 
 gsfproxy_root  := $(LOCAL_PATH)
 gsfproxy_dir   := services-framework-proxy
-gsfproxy_out   := $(TARGET_COMMON_OUT_ROOT)/obj/APPS/$(LOCAL_MODULE)_intermediates
+gsfproxy_out   := $(realpath $(TARGET_COMMON_OUT_ROOT))/obj/APPS/$(LOCAL_MODULE)_intermediates
 gsfproxy_build := $(gsfproxy_root)/$(gsfproxy_dir)/build
 gsfproxy_apk   := build/outputs/apk/services-framework-proxy-release-unsigned.apk
 


### PR DESCRIPTION
The symlink created by Android.mk is in LOCAL_PATH, while
OUT_DIR may be relative to the top directory (AOSP 8.0),
causing the symlink to point at a wrong location.

Make sure the symlink points at an absolute path.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>