### PR TITLE
Updating GsfProxy versions and enabling direct ROM build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -34,7 +34,7 @@ preps_gsf:
 $(gsfproxy_root)/$(gsfproxy_dir)/$(gsfproxy_apk): preps_gsf
 	echo "sdk.dir=$(ANDROID_HOME)" > $(gsfproxy_root)/local.properties; \
 	cd $(gsfproxy_root) && git submodule update --recursive --init; \
-	cd $(gsfproxy_root)/$(gsfproxy_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
+	cd $(gsfproxy_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true

--- a/Android.mk
+++ b/Android.mk
@@ -23,14 +23,17 @@ gsfproxy_root  := $(LOCAL_PATH)
 gsfproxy_dir   := services-framework-proxy
 gsfproxy_out   := $(TARGET_COMMON_OUT_ROOT)/obj/APPS/$(LOCAL_MODULE)_intermediates
 gsfproxy_build := $(gsfproxy_root)/$(gsfproxy_dir)/build
-gsfproxy_apk   := build/outputs/apk/services-framework-proxy-release-unsigned.apk
+gsfproxy_apk   := build/outputs/apk/release/services-framework-proxy-release-unsigned.apk
 
-$(gsfproxy_root)/$(gsfproxy_dir)/$(gsfproxy_apk):
-	rm -Rf $(gsfproxy_build)
-	mkdir -p $(gsfproxy_out)
-	ln -s $(gsfproxy_out) $(gsfproxy_build)
-	echo "sdk.dir=$(ANDROID_HOME)" > $(gsfproxy_root)/local.properties
-	cd $(gsfproxy_root) && git submodule update --recursive --init
+.PHONY: preps_gsf
+preps_gsf:
+	rm -rf $(gsfproxy_build); \
+	mkdir -p $(ANDROID_BUILD_TOP)/$(gsfproxy_out); \
+	ln -s $(ANDROID_BUILD_TOP)/$(gsfproxy_out)/ $(ANDROID_BUILD_TOP)/$(gsfproxy_build)
+
+$(gsfproxy_root)/$(gsfproxy_dir)/$(gsfproxy_apk): preps_gsf
+	echo "sdk.dir=$(ANDROID_HOME)" > $(gsfproxy_root)/local.properties; \
+	cd $(gsfproxy_root) && git submodule update --recursive --init; \
 	cd $(gsfproxy_root)/$(gsfproxy_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform

--- a/Android.mk
+++ b/Android.mk
@@ -37,6 +37,7 @@ $(gsfproxy_root)/$(gsfproxy_dir)/$(gsfproxy_apk): preps_gsf
 	cd $(gsfproxy_root)/$(gsfproxy_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := true
 LOCAL_SRC_FILES := $(gsfproxy_dir)/$(gsfproxy_apk)
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def androidCompileSdk() { return 27 }
 
 def androidTargetSdk() { return 27 }
 
-def androidMinSdk() { return 10 }
+def androidMinSdk() { return 9 }
 
 def versionCode() {
     def stdout = new ByteArrayOutputStream()

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,24 +17,27 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 
 allprojects {
     apply plugin: 'idea'
-    ext.androidBuildVersionTools = "24.0.3"
+    ext.androidBuildVersionTools = "27.0.3"
+    ext.supportLibraryVersion = "27.1.0"
     ext.isReleaseVersion = false
+    ext.slf4jVersion = "1.7.25"
 }
 
-def androidCompileSdk() { return 24 }
+def androidCompileSdk() { return 27 }
 
-def androidTargetSdk() { return 24 }
+def androidTargetSdk() { return 27 }
 
-def androidMinSdk() { return 9 }
+def androidMinSdk() { return 10 }
 
 def versionCode() {
     def stdout = new ByteArrayOutputStream()
@@ -55,11 +58,12 @@ subprojects {
     group = 'org.microg'
     repositories {
         jcenter()
+        google()
     }
 
     tasks.withType(JavaCompile) {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip

--- a/services-framework-proxy/build.gradle
+++ b/services-framework-proxy/build.gradle
@@ -41,6 +41,13 @@ android {
     defaultConfig {
         versionName getMyVersionName()
         versionCode getMyVersionCode()
+        minSdkVersion androidMinSdk()
+        targetSdkVersion androidTargetSdk()
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
Similar to FakeStore I updated the versions according to the rest of the project and adapted a few things to allow for direct build within a ROM. I tested this with a Sony AOSP build and was using it for a while without errors.

Would be happy to have this included in the microg repository (e.g. as version 0.2?), as I then can close the fork.

Regular build should be unaffected, at least it is in my setup.