### PR TITLE
ext.androidTargetSdk = 30 to allow AOSP15 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 
     ext.appVersionCode = versionCode()
     ext.androidCompileSdk = 30
-    ext.androidTargetSdk = 24
+    ext.androidTargetSdk = 30
     ext.androidMinSdk = 9
 }
 


### PR DESCRIPTION
ext.androidTargetSdk is too low for android 15 and you need to force installs via ADB, this is not ideal, and the gsf proxy needs to be updated as it is essentially obsolete because of this SDK requirement